### PR TITLE
Add /lfx entry point and PM-friendly improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,9 @@ Thumbs.db
 # Claude AI assistant
 .claude
 
+# Installed skill symlinks (created by per-repo installation)
+.claude/skills/
+
 # Environment and configuration files
 .env
 .env.local

--- a/README.md
+++ b/README.md
@@ -2,12 +2,36 @@
 
 A collection of specialized Claude Code skills that encode the full development workflow for the LFX Self-Service platform. These skills turn Claude into a context-aware development partner that understands LFX conventions, architecture, and code patterns — eliminating the need to repeatedly explain project structure, naming rules, or coding standards.
 
+## Quick Install
+
+```bash
+git clone https://github.com/linuxfoundation/skills.git
+cd skills
+./install.sh
+```
+
+Then restart Claude Code, open any LFX repo, and type `/lfx` to get started.
+
+## How It Works
+
+Type `/lfx` and describe what you want in plain language:
+
+- **"Add a bio field to committee members"** — builds the full-stack feature automatically
+- **"How does the meeting data flow work?"** — explains the architecture in plain language
+- **"Check if my changes are ready for a PR"** — validates everything and offers to create the PR
+
+The `/lfx` skill auto-detects your repo, branch, and context, then routes you to the right workflow. No need to know which of the 8 skills to pick — just describe what you want.
+
+New to LFX development? Type `/lfx` and say **"show me an example"** for a walkthrough.
+
 ## Prerequisites
 
 - [Claude Code](https://docs.anthropic.com/en/docs/claude-code) installed and authenticated
 - Access to LFX repositories (for the skills to operate on)
 
-## Installation
+## Manual Installation
+
+If you prefer to install manually instead of using `./install.sh`:
 
 ### Step 1: Clone this repo
 
@@ -22,18 +46,19 @@ Claude Code auto-discovers skills from `~/.claude/skills/`. Symlink each skill i
 ```bash
 # From the cloned repo directory
 mkdir -p ~/.claude/skills
-for skill in lfx-*/; do
+for skill in lfx-*/ lfx/; do
   ln -sf "$(pwd)/$skill" ~/.claude/skills/"$(basename "$skill")"
 done
 ```
 
-This makes all seven `/lfx-*` skills available globally in every Claude Code session.
+This makes all `/lfx*` skills available globally in every Claude Code session.
 
 ### Step 3: Verify
 
-Restart Claude Code (or open a new session) in any LFX repo and type `/lfx-` — you should see all seven skills in the autocomplete list:
+Restart Claude Code (or open a new session) in any LFX repo and type `/lfx` — you should see all skills in the autocomplete list:
 
 ```
+/lfx                    ← start here (plain-language entry point)
 /lfx-coordinator
 /lfx-research
 /lfx-backend-builder
@@ -50,7 +75,7 @@ If you prefer skills scoped to a specific repo instead of global:
 ```bash
 # From inside a target repo (e.g., lfx-v2-ui)
 mkdir -p .claude/skills
-for skill in /path/to/skills/lfx-*/; do
+for skill in /path/to/skills/lfx-*/ /path/to/skills/lfx/; do
   ln -sf "$skill" .claude/skills/"$(basename "$skill")"
 done
 
@@ -62,6 +87,7 @@ echo '.claude/skills/' >> .gitignore
 
 ```bash
 rm -f ~/.claude/skills/lfx-*
+rm -f ~/.claude/skills/lfx
 ```
 
 ## Architecture
@@ -70,6 +96,9 @@ The skills form a layered system where each skill has a clear responsibility and
 
 ```
 ┌─────────────────────────────────────────────────────────┐
+│                    /lfx (entry point)                     │
+│     Plain-language router — describe what you want       │
+├─────────────────────────────────────────────────────────┤
 │              /lfx-coordinator (orchestrator)             │
 │       Researches, plans, delegates, validates            │
 ├──────────┬──────────┬───────────────┬───────────────────┤
@@ -86,6 +115,7 @@ The skills form a layered system where each skill has a clear responsibility and
 
 | Skill | Purpose | Mode | Tools |
 |-------|---------|------|-------|
+| **`/lfx`** | **Start here.** Describe what you want in plain language — auto-detects context and routes to the right skill | Router | Bash, Read, Glob, Grep, AskUserQuestion, **Skill** |
 | `/lfx-coordinator` | Orchestrates full feature development — researches, plans, delegates to builders in parallel, validates | Read + delegate | Bash, Read, Glob, Grep, AskUserQuestion, **Skill** |
 | `/lfx-research` | Explores upstream APIs, discovers code patterns, reads architecture docs, validates contracts via MCP | Read-only | Bash, Read, Glob, Grep, AskUserQuestion, **WebFetch** |
 | `/lfx-backend-builder` | Generates Express.js proxy endpoints, Go microservice code, shared types. Encodes three-file pattern, logging, Goa DSL, NATS messaging | Code gen | Bash, Read, **Write, Edit**, Glob, Grep, AskUserQuestion |
@@ -281,6 +311,13 @@ An **interactive setup guide** that walks through environment configuration step
 
 ## Typical Workflows
 
+### Start here — just describe what you want
+```
+/lfx → "Add a bio field to committee members" → auto-routes to coordinator → builds → validates → PR
+/lfx → "How does meeting data work?" → auto-routes to product architect → explains architecture
+/lfx → "Check if my changes are ready" → auto-routes to preflight → validates → offers PR creation
+```
+
 ### Build a new feature end-to-end
 ```
 /lfx-coordinator → researches → plans → delegates to /lfx-backend-builder + /lfx-ui-builder → validates → /lfx-preflight → PR
@@ -315,6 +352,11 @@ An **interactive setup guide** that walks through environment configuration step
 ## Project Structure
 
 ```
+├── lfx/
+│   ├── SKILL.md                    # Entry point — plain-language router
+│   └── references/
+│       ├── glossary.md             # LFX terms explained in plain language
+│       └── quickstart.md           # Example workflow transcripts
 ├── lfx-coordinator/
 │   ├── SKILL.md                    # Orchestrator — plans, delegates, validates
 │   └── references/

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# Copyright The Linux Foundation and each contributor to LFX.
+# SPDX-License-Identifier: MIT
+
+# LFX Skills Installer
+# Symlinks all LFX skills into ~/.claude/skills/ so they're available globally in Claude Code.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SKILLS_DIR="$HOME/.claude/skills"
+
+echo "Installing LFX skills..."
+echo ""
+
+# Create the skills directory if it doesn't exist
+mkdir -p "$SKILLS_DIR"
+
+# Track results
+installed=0
+updated=0
+failed=0
+
+# Install each skill directory (lfx-* and lfx/)
+for skill_path in "$SCRIPT_DIR"/lfx-*/ "$SCRIPT_DIR"/lfx/; do
+  [ -d "$skill_path" ] || continue
+
+  skill_name="$(basename "$skill_path")"
+  target="$SKILLS_DIR/$skill_name"
+
+  if [ -L "$target" ]; then
+    # Symlink exists — update it
+    rm "$target"
+    ln -s "$skill_path" "$target"
+    echo "  Updated  $skill_name"
+    updated=$((updated + 1))
+  elif [ -e "$target" ]; then
+    # Something else exists at the target path
+    echo "  Skipped  $skill_name (non-symlink already exists at $target)"
+    failed=$((failed + 1))
+  else
+    ln -s "$skill_path" "$target"
+    echo "  Installed  $skill_name"
+    installed=$((installed + 1))
+  fi
+done
+
+echo ""
+echo "Done! $((installed + updated)) skills ready ($installed new, $updated updated)."
+
+if [ $failed -gt 0 ]; then
+  echo "$failed skills skipped due to conflicts — check the paths above."
+fi
+
+echo ""
+echo "Next steps:"
+echo "  1. Restart Claude Code (or open a new session)"
+echo "  2. Type /lfx to get started"
+echo ""
+echo "Available skills:"
+for skill_path in "$SKILLS_DIR"/lfx*; do
+  [ -e "$skill_path" ] || continue
+  echo "  /$(basename "$skill_path")"
+done

--- a/lfx-coordinator/SKILL.md
+++ b/lfx-coordinator/SKILL.md
@@ -17,15 +17,16 @@ You coordinate development across LFX repos. You NEVER write code — you delega
 
 ## Input Validation
 
-Before starting, verify you have enough context. If any of these are missing, ask the user:
+Before starting, verify you have enough context. Auto-detect as much as possible — minimize questions to the user.
 
-| Required | Example | If Missing |
-|----------|---------|------------|
-| What to build/fix | "Add bio field to committee members" | Ask: "What feature or fix do you need?" |
-| Which domain | committees, meetings, votes | Infer from context or ask |
-| Scope | New feature, bug fix, field addition | Ask if ambiguous |
+| Required | How to Get It |
+|----------|---------------|
+| What to build/fix | If not clear from context, ask: "What feature or fix do you need?" |
+| Which domain | **Auto-detect** from the user's description: "committee member bio" → committees, "meeting attendance" → meetings, "vote results" → voting, "mailing list" → mailing lists. Only ask if truly ambiguous. |
+| Scope | **Auto-classify**: adding a field → field addition, new page → new feature, something broken → bug fix, changing behavior → modification. Never ask the user to classify. |
+| Branch | **Auto-derive** from JIRA ticket if mentioned (e.g., LFXV2-456 → `feat/LFXV2-456-description`), or suggest one based on the feature description. Don't ask the user for a branch name. |
 
-**Reject vague requests** like "improve the committees page" — ask for specifics.
+**Reject vague requests** like "improve the committees page" — but ask in plain language: "Could you tell me specifically what you'd like to add or change about the committees page?"
 
 ## Workflow
 
@@ -80,12 +81,22 @@ Use your Read, Glob, Grep, and Bash tools to quickly check:
 
 ## Step 4: Delegation Plan (PAUSE for approval)
 
-After research, output this format:
+After research, output a **plain-language summary first**, then technical details:
 
 ```
 ═══════════════════════════════════════════
-DELEGATION PLAN
+HERE'S WHAT I'M GOING TO DO
 ═══════════════════════════════════════════
+
+  1. [Plain-language step — e.g., "Add the bio data field to the committee service"]
+  2. [Plain-language step — e.g., "Update the shared data definitions"]
+  3. [Plain-language step — e.g., "Add a bio text input to the member form"]
+  4. [Plain-language step — e.g., "Display the bio on the member card"]
+
+Shall I proceed?
+
+TECHNICAL DETAILS (for reference)
+─────────────────────────────────
 
 Findings:
   - [what exists]
@@ -105,7 +116,6 @@ Risk flags:
   - [missing upstream API — blocks frontend until Go service is updated]
 
 ═══════════════════════════════════════════
-Proceed? (y/n)
 ```
 
 ### Upstream Go service changes are NOT optional
@@ -220,6 +230,16 @@ If validation fails:
 4. **Re-run validation** after the fix
 5. **Maximum 2 fix cycles** — if still failing after 2 attempts, report the remaining errors to the user
 
+**Plain-language error reporting:** When reporting errors to the user, translate technical errors into plain language:
+
+```
+Something went wrong during validation:
+  - What failed: The build couldn't find the bio field definition in the shared types
+  - What this means: The backend and frontend aren't in sync yet
+  - Can I fix it? Yes — I'll update the shared type definition and rebuild
+  - What you need to do: Nothing — I'll handle this automatically
+```
+
 ### Handling Skill Failures
 
 If a delegated skill reports an error in its completion report:
@@ -230,12 +250,28 @@ If a delegated skill reports an error in its completion report:
 
 ## Step 7: Summary
 
-Output a structured completion report:
+Output a **business summary first** (what the user cares about), then technical details (for reviewers):
 
 ```
 ═══════════════════════════════════════════
-DEVELOPMENT COMPLETE
+WHAT WAS DONE
 ═══════════════════════════════════════════
+
+You asked: "[original request in the user's own words]"
+
+What changed:
+  - [Plain-language description of each user-visible change]
+  - [e.g., "Committee members now have a bio text field"]
+  - [e.g., "The bio appears on the member profile card"]
+  - [e.g., "The bio can be edited in the member form"]
+
+What happens next:
+  - Run /lfx-preflight to validate your changes
+  - Create a pull request for code review
+  [- If cross-repo: "The Go service changes need to be deployed before the frontend changes will work"]
+
+TECHNICAL DETAILS (for reviewers)
+─────────────────────────────────
 
 Feature: [what was built]
 Branch: [branch name]
@@ -256,7 +292,6 @@ Code owner actions needed: [none / list protected file changes]
 Cross-repo dependencies: [e.g., "Go service must be deployed before frontend works"]
 
 ═══════════════════════════════════════════
-Next: Run /lfx-preflight before submitting your PR.
 ```
 
 ## Idempotency — Safe to Re-run

--- a/lfx-preflight/SKILL.md
+++ b/lfx-preflight/SKILL.md
@@ -206,10 +206,18 @@ List:
 
 ## Results Report
 
+**Start with a one-line plain-language verdict** before any details:
+
 ```text
 ═══════════════════════════════════════════
 PREFLIGHT RESULTS
 ═══════════════════════════════════════════
+
+YOUR CHANGES LOOK GOOD AND ARE READY FOR REVIEW!
+(or: FOUND 2 ISSUES THAT NEED ATTENTION — see below)
+
+─────────────────────────────────────────
+Detailed checks:
 ✓ Working tree        — Clean, N commits ahead of main
 ✓ License headers     — All files have headers (2 auto-fixed)
 ✓ Formatting          — Applied (3 files reformatted)
@@ -247,12 +255,16 @@ If there are uncommitted changes from auto-fixes, ask:
 
 ### If All Checks Pass
 
-> "All preflight checks passed! Ready to create a PR. Would you like me to create it with `gh pr create`?"
+> "Your changes look good and are ready for review! Would you like me to create the pull request?"
 
 ### If Checks Fail
 
-Report all failures together, then ask:
-> "N issues found. Would you like me to fix what I can automatically?"
+Report failures in plain language, explaining what each means:
+> "Found 2 issues that need attention:
+> 1. **Build error**: [plain explanation of what went wrong and whether it can be auto-fixed]
+> 2. **Missing signoff**: [plain explanation and what the user needs to do]
+>
+> Want me to fix what I can automatically?"
 
 ## Scope Boundaries
 

--- a/lfx-setup/SKILL.md
+++ b/lfx-setup/SKILL.md
@@ -14,7 +14,18 @@ allowed-tools: Bash, Read, Glob, Grep, AskUserQuestion
 
 You are helping a contributor set up an LFX development environment from scratch. Walk through each step interactively, verifying success before moving on.
 
-**Key principle:** Verify each step before proceeding to the next. Don't assume success — check.
+**Key principle:** Verify each step before proceeding to the next.
+
+## What You'll Need (before we start)
+
+Before diving into the technical steps, here's what you should have ready:
+
+- **Access to the LFX GitHub organization** — you need to be able to clone LFX repositories. If you can visit `github.com/linuxfoundation` and see private repos, you're good.
+- **Access to the team 1Password vault** — some configuration values (API keys, secrets) are stored in 1Password under the "LFX One Dev Environment" vault. Ask your team lead if you don't have access.
+- **About 15 minutes** — first-time setup takes a bit for downloads and installs. Subsequent setups are faster.
+- **A terminal app** — Terminal.app (macOS), iTerm2, or any terminal emulator.
+
+Don't worry if you're not sure about any of these — I'll check each one as we go and help you get access if needed. Don't assume success — check.
 
 ## Repo Type Detection
 

--- a/lfx/SKILL.md
+++ b/lfx/SKILL.md
@@ -1,0 +1,197 @@
+---
+name: lfx
+description: >
+  Starting point for LFX development. Describe what you want in plain language
+  and this skill routes you to the right workflow.
+allowed-tools: Bash, Read, Glob, Grep, AskUserQuestion, Skill
+---
+
+<!-- Copyright The Linux Foundation and each contributor to LFX. -->
+<!-- SPDX-License-Identifier: MIT -->
+
+# LFX — Your Starting Point
+
+You are the friendly entry point for anyone working on LFX. Your job is to understand what the user wants in plain language, gather context automatically, and route them to the right specialized skill. You never write code directly.
+
+## When This Skill Loads
+
+Greet the user and offer to help:
+
+```
+Welcome to LFX development! What would you like to do?
+
+Here are some things I can help with:
+  - "Add a bio field to committee members"
+  - "How does the meeting data flow work?"
+  - "Check if my changes are ready for a pull request"
+  - "Set up my development environment"
+  - "Understand the committee service architecture"
+
+New here? Say "show me an example" for a walkthrough.
+```
+
+## Step 1: Detect Environment
+
+Before asking any questions, silently gather context:
+
+```bash
+# What repo are we in?
+if [ -f apps/lfx-one/angular.json ] || [ -f turbo.json ]; then
+  echo "REPO_TYPE=angular"
+elif [ -f go.mod ]; then
+  echo "REPO_TYPE=go"
+else
+  echo "REPO_TYPE=unknown"
+fi
+
+# What branch?
+git branch --show-current 2>/dev/null
+
+# Any uncommitted work?
+git status --porcelain 2>/dev/null | head -5
+
+# What's the repo name?
+basename "$(git rev-parse --show-toplevel 2>/dev/null)" 2>/dev/null
+```
+
+Present this in plain language if relevant:
+
+```
+I can see you're working in the [repo name] repository ([Angular frontend / Go microservice]).
+You're on the [branch] branch [with/without uncommitted changes].
+```
+
+If not in an LFX repo, say: "I don't see an LFX repo here. Would you like to set one up? I can walk you through it."
+
+## Step 2: Understand Intent
+
+Listen to what the user says and classify their intent. **Do not ask technical questions** — infer from context.
+
+| If the user says something like... | They want... | Route to... |
+|-------------------------------------|-------------|-------------|
+| "Add ...", "Build ...", "Create ...", "Fix ...", "Change ...", "Update ..." | To build or modify code | `/lfx-coordinator` |
+| "How does ... work?", "Where is ...", "Explain ...", "Architecture of ..." | To understand the system | `/lfx-product-architect` |
+| "What APIs ...", "Does ... exist?", "Find ...", "Research ..." | To explore and research | `/lfx-research` |
+| "Check my changes", "Ready for PR?", "Validate ...", "Preflight" | To validate before PR | `/lfx-preflight` |
+| "Set up", "Install", "Environment", "Getting started" | Environment setup | `/lfx-setup` |
+| "Show me an example", "How do I use this?", "Help" | Guidance | Show quickstart examples |
+
+## Step 3: Translate and Route
+
+When routing to a skill, translate the user's plain-language request into the format the skill expects. The user should never need to know the technical details.
+
+### Routing to `/lfx-coordinator`
+
+Auto-detect these instead of asking:
+
+- **Domain**: Infer from the user's description
+  - "committee member bio" → committees
+  - "meeting attendance" → meetings
+  - "vote results" → voting
+  - "mailing list subscribers" → mailing lists
+- **Scope**: Classify automatically
+  - Adding a field → "field addition"
+  - New page or feature → "new feature"
+  - Something broken → "bug fix"
+  - Changing behavior → "modification"
+- **Branch**: Auto-derive from JIRA ticket if mentioned, or suggest one based on the feature description
+
+Invoke the skill with a clear, specific description:
+
+```
+Skill(skill: "lfx-coordinator", args: "Add a bio text field to committee members. Domain: committees. Scope: field addition. The user wants committee members to have a bio that can be edited in the form and displayed on the member card.")
+```
+
+### Routing to `/lfx-product-architect`
+
+Pass the question directly — this skill is already approachable:
+
+```
+Skill(skill: "lfx-product-architect", args: "How does the meeting data flow from the frontend to the Go service and back?")
+```
+
+### Routing to `/lfx-research`
+
+Translate the question into a research task:
+
+```
+Skill(skill: "lfx-research", args: "Check if the committee service API already has a bio field. Look at the Go domain model and the OpenAPI spec.")
+```
+
+### Routing to `/lfx-preflight`
+
+No translation needed — just invoke:
+
+```
+Skill(skill: "lfx-preflight")
+```
+
+### Routing to `/lfx-setup`
+
+No translation needed — just invoke:
+
+```
+Skill(skill: "lfx-setup")
+```
+
+### Showing Examples
+
+When the user asks for examples or help, read and present the quickstart guide:
+
+```
+Read the file at: <skill-directory>/references/quickstart.md
+```
+
+Present the examples conversationally, not as raw markdown.
+
+## Step 4: Explain Jargon
+
+If the user encounters unfamiliar terms during any workflow, or if you notice jargon in skill output, explain it in plain language. Reference the glossary:
+
+```
+Read the file at: <skill-directory>/references/glossary.md
+```
+
+Use these explanations inline — don't dump the whole glossary. For example:
+
+- If output mentions "Goa design" → "Goa is the framework that defines the API — think of it as the blueprint for what the service accepts and returns."
+- If output mentions "NATS" → "NATS is the messaging system that lets services talk to each other — when you save data in one place, NATS tells other services to update too."
+- If output mentions "FGA" → "FGA (Fine-Grained Authorization) controls who can see and edit what — it's the permissions system."
+
+## Handling Ambiguity
+
+If the user's request is genuinely unclear (not just missing technical details), ask ONE clarifying question in plain language:
+
+- "It sounds like you want to change how committee members are displayed. Could you tell me specifically what you'd like to add or change?"
+- "I see a few things that could mean — are you looking to add a new data field, or change how an existing field appears?"
+
+**Never ask:**
+- "What branch name do you want?"
+- "Which domain does this belong to?"
+- "What's the scope classification?"
+- "Is this a Go or Angular change?"
+
+These should all be auto-detected or inferred.
+
+## After Routing
+
+Once the delegated skill completes, check back with the user:
+
+- If they built something → "Your changes are ready! Would you like me to run a preflight check before you submit a PR?"
+- If they researched something → "Would you like to go ahead and build this, or do you have more questions?"
+- If they validated → "Everything looks good! Want me to help create the pull request?"
+
+## Scope Boundaries
+
+**This skill DOES:**
+- Greet users and understand their intent
+- Auto-detect repo type, branch, and context
+- Translate plain language into skill-specific args
+- Route to the right skill
+- Explain jargon when encountered
+- Suggest next steps after a workflow completes
+
+**This skill does NOT:**
+- Write or modify code (delegates to other skills)
+- Make architectural decisions (delegates to `/lfx-product-architect`)
+- Run validation directly (delegates to `/lfx-preflight`)

--- a/lfx/references/glossary.md
+++ b/lfx/references/glossary.md
@@ -1,0 +1,43 @@
+<!-- Copyright The Linux Foundation and each contributor to LFX. -->
+<!-- SPDX-License-Identifier: MIT -->
+
+# LFX Glossary
+
+A plain-language reference for terms you'll encounter when working on LFX.
+
+## Platform Terms
+
+| Term | What It Is | Why It Matters |
+|------|-----------|----------------|
+| **Goa** | A Go framework that defines API endpoints using a design DSL. You describe what your API accepts and returns, and Goa generates the boilerplate code. | When adding a new field or endpoint, you edit the Goa "design" files and run `make apigen` to regenerate the server code. |
+| **NATS** | A messaging system that lets services communicate. When one service saves data, it sends a message via NATS so other services can react (e.g., update search indexes, sync permissions). | If you add a new data type, it needs NATS messages so search and permissions stay in sync. |
+| **OpenFGA (FGA)** | The permissions system. Controls who can view, edit, or delete each resource. Uses "tuples" (relationships like "user X is an editor of project Y"). | Every new resource needs FGA rules, otherwise nobody can access it — or everybody can. |
+| **Heimdall** | An authorization gateway that sits in front of every API request. Checks if the caller has permission before the request reaches the service. | API routes need Heimdall rules in the Helm chart, or requests get rejected. |
+| **OpenSearch** | A search and analytics engine (similar to Elasticsearch). Stores indexed copies of data for fast querying, filtering, and full-text search. | The query service reads from OpenSearch, not directly from the Go services. New data needs an indexer to get into OpenSearch. |
+| **KV (Key-Value store)** | NATS-based key-value storage used for caching and lightweight data that doesn't need a full database. | Some services use KV for quick lookups like configuration or temporary state. |
+| **PrimeNG** | A UI component library for Angular. LFX wraps PrimeNG components with `lfx-` prefixed wrappers to enforce consistent styling. | When building UI, use `lfx-table`, `lfx-button`, etc. — not raw PrimeNG components directly. |
+| **Express proxy** | A Node.js server layer in the Angular app that forwards API requests to upstream Go services. Handles auth, logging, and request transformation. | Frontend components don't call Go services directly — they go through the Express proxy. |
+
+## Architecture Terms
+
+| Term | PM Translation |
+|------|---------------|
+| **Three-file pattern** | Every backend endpoint needs three files: a service (talks to upstream), a controller (handles the request), and a route (defines the URL). Think of it as: plumbing, logic, and address. |
+| **Upstream Go service** | The backend service that owns the data. For example, the committee service owns all committee data. The Angular app never talks to it directly — it goes through the Express proxy. |
+| **Resource service** | A Go microservice that owns one type of data (committees, meetings, votes, etc.). Each has its own repo, database, and API. |
+| **Shared types** | TypeScript interfaces in a shared package that both the frontend and backend use. Keeps data shapes consistent. When you add a field, it goes here first. |
+| **Domain model** | The Go struct that defines what a data object looks like in the backend (its fields and types). This is the source of truth for the data shape. |
+| **Goa design** | The API blueprint files that define endpoints, request/response types, and validation rules. Changes here + `make apigen` = updated API code. |
+| **Signal (Angular)** | A reactive value in Angular. When it changes, any UI that uses it automatically updates. Think of it like a spreadsheet cell — change the value, and everything that references it recalculates. |
+
+## Workflow Terms
+
+| Term | When You See It |
+|------|----------------|
+| **Preflight** | A set of automated checks run before submitting a pull request — formatting, linting, building, and checking for protected files. Like a checklist before takeoff. |
+| **Protected file** | A file that requires special approval to change (e.g., server configuration, build settings). Changes to these files will be flagged in the PR. |
+| **Code owner** | A team member who must approve changes to certain files. Protected files always need code owner review. |
+| **Feature branch** | A separate copy of the code where you make changes without affecting the main codebase. Named like `feat/LFXV2-123-add-bio-field`. |
+| **Delegation plan** | The coordinator's breakdown of what needs to happen, in what order, and which skills will do each part. You approve this before any code is written. |
+| **Auto-fix** | Preflight can automatically fix some issues (formatting, missing license headers) without you doing anything. It asks before committing these fixes. |
+| **Signoff** | A line in each commit (`Signed-off-by: Name <email>`) required by Linux Foundation projects for legal compliance. |

--- a/lfx/references/quickstart.md
+++ b/lfx/references/quickstart.md
@@ -1,0 +1,140 @@
+<!-- Copyright The Linux Foundation and each contributor to LFX. -->
+<!-- SPDX-License-Identifier: MIT -->
+
+# LFX Quickstart Examples
+
+Three real workflow examples showing how to use `/lfx` from start to finish.
+
+---
+
+## Example 1: "Add a field to committee members"
+
+**Scenario:** You want committee members to have a bio field that appears on their profile card and can be edited in the member form.
+
+### What you type:
+
+```
+/lfx
+Add a bio field to committee members
+```
+
+### What happens:
+
+**LFX detects your environment:**
+> I can see you're working in the lfx-v2-ui repository (Angular frontend).
+> You're on the main branch with no uncommitted changes.
+
+**LFX routes to the coordinator and presents a plan:**
+> Here's what I'm going to do:
+> 1. Add the "bio" data field to the committee Go service
+> 2. Update the shared data definitions so both frontend and backend know about it
+> 3. Add a bio text input to the member edit form
+> 4. Display the bio on the member profile card
+>
+> Shall I proceed?
+
+**You say:** yes
+
+**LFX builds everything in parallel, then reports:**
+> **What was done:**
+> - Committee members now have a bio text field
+> - The bio appears on the member profile card
+> - The bio can be edited in the member form
+>
+> **What happens next:**
+> - Run `/lfx-preflight` to validate your changes
+> - Create a pull request for code review
+
+**You say:** run preflight
+
+**LFX validates and reports:**
+> Your changes look good and are ready for review!
+> All checks passed: formatting, linting, build, and license headers.
+> Would you like me to create the pull request?
+
+---
+
+## Example 2: "Understand how meeting data works"
+
+**Scenario:** You want to understand the data flow for meetings before planning a new feature.
+
+### What you type:
+
+```
+/lfx
+How does the meeting data flow work?
+```
+
+### What happens:
+
+**LFX routes to the product architect:**
+> Here's how meeting data flows through the system:
+>
+> **When a user views meetings:**
+> 1. The Angular frontend calls `/api/meetings/...`
+> 2. The Express proxy forwards this to the meeting Go service
+> 3. For listing/searching, it actually goes to the query service, which reads from OpenSearch (a search engine that has indexed copies of meeting data)
+>
+> **When a user creates or edits a meeting:**
+> 1. The frontend sends the data to the Express proxy
+> 2. The proxy forwards to the meeting Go service
+> 3. The Go service saves it and sends a message via NATS (the messaging system)
+> 4. Other services react: the indexer updates OpenSearch, the permissions system updates access rules
+>
+> **Key files:**
+> - Frontend components: `apps/lfx-one/src/app/modules/meetings/`
+> - Express proxy: `apps/lfx-one/src/server/services/meeting.service.ts`
+> - Go service: `lfx-v2-meeting-service` (separate repo)
+
+**You say:** Great, now I want to add an attendance tracking feature to meetings
+
+**LFX routes to the coordinator** and starts the build workflow.
+
+---
+
+## Example 3: "Check if my changes are ready"
+
+**Scenario:** You've made some changes (or a skill made them for you) and want to make sure everything is good before submitting a pull request.
+
+### What you type:
+
+```
+/lfx
+Are my changes ready for a PR?
+```
+
+### What happens:
+
+**LFX runs preflight validation:**
+> Checking your changes...
+>
+> **Your changes look good and are ready for review!**
+>
+> - Formatting: All files properly formatted
+> - Linting: No errors found
+> - Build: Succeeded
+> - License headers: All present (2 were auto-fixed)
+> - Protected files: None modified
+> - Commits: Properly signed off with JIRA reference
+>
+> Auto-fixes applied:
+> - Added license headers to 2 new files
+>
+> Would you like me to commit the auto-fixes and create the pull request?
+
+**If something is wrong:**
+> Found 2 issues that need attention:
+>
+> 1. **Build error**: The `MemberCardComponent` is trying to use `member.bio` but the import for the updated interface is missing. I can fix this automatically.
+> 2. **Missing signoff**: Your last commit doesn't have a `Signed-off-by` line. You'll need to amend it with `git commit --amend --signoff`.
+>
+> Want me to fix issue #1 automatically?
+
+---
+
+## Tips
+
+- **You don't need to know which skill to use.** Just describe what you want to `/lfx` and it figures out the right workflow.
+- **You don't need to provide technical details.** The system auto-detects your repo, branch, and domain.
+- **You can chain workflows.** After building, say "check my changes" to run preflight. After preflight, say "create the PR."
+- **If you see unfamiliar terms,** just ask: "What does Goa mean?" or "What's a protected file?" and LFX will explain in plain language.


### PR DESCRIPTION
## Summary

- **New `/lfx` entry-point skill** — plain-language router that greets users, auto-detects repo/branch/context, maps intent to the right skill, and translates PM-speak into technical args
- **Shared glossary** (`lfx/references/glossary.md`) — Platform Terms (Goa, NATS, FGA, Heimdall, etc.), Architecture Terms, and Workflow Terms explained in plain language
- **Quickstart examples** (`lfx/references/quickstart.md`) — three workflow transcripts showing /lfx end-to-end
- **One-command installer** (`install.sh`) — replaces manual symlink setup
- **PM-friendly coordinator output** — business summary before technical details, auto-detection of domain/scope/branch, plain-language error recovery
- **Preflight verdict** — one-line plain-language result at top ("Your changes look good" or "Found N issues")
- **Setup prerequisites** — "What You'll Need" section in non-technical terms
- **README overhaul** — leads with quick install and /lfx, updated architecture diagram and skill table

## Test plan

- [ ] Run `./install.sh` — verify all 8 skills appear with checkmarks
- [ ] Open Claude Code in an LFX repo, type `/lfx` — verify entry-point skill loads and asks "What would you like to do?"
- [ ] Describe a feature in plain language — verify it routes to coordinator with correct args
- [ ] Run `/lfx-coordinator` with a simple feature request — verify business summary appears before technical details in delegation plan and completion report
- [ ] Run `/lfx-preflight` — verify plain-language verdict appears at top of results
- [ ] Check glossary terms against existing reference docs for accuracy