### PR TITLE
feat: replace hardcoded ~/lf/ with dynamic linuxfoundation org discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -316,7 +316,7 @@ Combines feature branches from one or more repos into isolated git worktrees for
 /lfx-test-journey
 ```
 This starts the interactive create flow:
-1. Select which repos are involved (auto-discovers repos in `~/lf/`)
+1. Select which repos are involved (auto-discovers repos by finding directories with `linuxfoundation` GitHub remotes)
 2. Pick branches to include per repo (shows your unmerged branches)
 3. Name the journey
 4. The skill creates worktrees, merges branches, and tells you exactly where to `cd` and how to run the app

--- a/lfx-coordinator/SKILL.md
+++ b/lfx-coordinator/SKILL.md
@@ -60,8 +60,19 @@ Use your Read, Glob, Grep, and Bash tools to quickly check:
   ```bash
   # Find the upstream service from the proxy code
   grep -r "proxyRequest" apps/lfx-one/src/server/services/<domain>.service.ts | head -5
+  # Resolve where linuxfoundation repos are cloned (check current repo's parent first)
+  if git remote -v 2>/dev/null | grep -q 'github\.com[:/]linuxfoundation/'; then
+    LFX_REPOS_DIR="$(dirname "$(git rev-parse --show-toplevel)")"
+  else
+    for candidate in ~/lf ~/code ~/projects ~/workspace ~/src ~/dev; do
+      if [ -d "$candidate" ] && find "$candidate" -maxdepth 2 -name .git -type d 2>/dev/null | while read gitdir; do git -C "$(dirname "$gitdir")" remote -v 2>/dev/null | grep -q 'github\.com[:/]linuxfoundation/' && echo found && break; done | grep -q found; then
+        LFX_REPOS_DIR="$candidate"; break
+      fi
+    done
+  fi
+  [ -n "${LFX_REPOS_DIR_OVERRIDE:-}" ] && LFX_REPOS_DIR="$LFX_REPOS_DIR_OVERRIDE"
   # Check for local Go repos
-  ls -d ~/lf/lfx-v2-*-service 2>/dev/null
+  ls -d "$LFX_REPOS_DIR"/lfx-v2-*-service 2>/dev/null
   ```
 - **Check the upstream Go service for the needed field.** Once you've identified the repo, check its domain model, Goa design, and conversions:
   ```bash
@@ -122,7 +133,7 @@ Risk flags:
 
 When research reveals that the upstream Go microservice is missing a field or endpoint that the feature requires, the delegation plan MUST include a `/lfx-backend-builder` call for the Go repo. This is where the data model lives — without it, the field won't persist. The Go service is the source of truth.
 
-**You discover the upstream service during research (Step 3)** by reading the Express proxy code. Do NOT hardcode paths — use what you found. For example, if `committee.service.ts` calls `proxyRequest(req, 'LFX_V2_SERVICE', '/committees/...')`, the API path prefix `/committees/` tells you the upstream is `lfx-v2-committee-service` and you check `~/lf/lfx-v2-committee-service/` for local availability.
+**You discover the upstream service during research (Step 3)** by reading the Express proxy code. Do NOT hardcode paths — use what you found. For example, if `committee.service.ts` calls `proxyRequest(req, 'LFX_V2_SERVICE', '/committees/...')`, the API path prefix `/committees/` tells you the upstream is `lfx-v2-committee-service` and you check `$LFX_REPOS_DIR/lfx-v2-committee-service/` for local availability (where `$LFX_REPOS_DIR` is the auto-discovered directory from Step 3).
 
 **Common Go service changes for adding a field:**
 - Domain model: `internal/domain/model/*.go` — add the field to the struct

--- a/lfx-research/SKILL.md
+++ b/lfx-research/SKILL.md
@@ -84,7 +84,22 @@ gh api repos/linuxfoundation/<repo-name>/contents/design/<file>.go \
 | Surveys | `lfx-v2-survey-service` |
 | Members | `lfx-v2-member-service` |
 
-**If the upstream Go repo exists locally** (check `~/lf/lfx-v2-*-service`), read the files directly instead of using `gh api`. Local reads are faster and more reliable.
+**If the upstream Go repo exists locally**, read the files directly instead of using `gh api`. Local reads are faster and more reliable. To find local repos, auto-detect where `linuxfoundation` org repos are cloned:
+
+```bash
+# Resolve the linuxfoundation repos directory
+if git remote -v 2>/dev/null | grep -q 'github\.com[:/]linuxfoundation/'; then
+  LFX_REPOS_DIR="$(dirname "$(git rev-parse --show-toplevel)")"
+else
+  for candidate in ~/lf ~/code ~/projects ~/workspace ~/src ~/dev; do
+    if [ -d "$candidate" ] && find "$candidate" -maxdepth 2 -name .git -type d 2>/dev/null | while read gitdir; do git -C "$(dirname "$gitdir")" remote -v 2>/dev/null | grep -q 'github\.com[:/]linuxfoundation/' && echo found && break; done | grep -q found; then
+      LFX_REPOS_DIR="$candidate"; break
+    fi
+  done
+fi
+[ -n "${LFX_REPOS_DIR_OVERRIDE:-}" ] && LFX_REPOS_DIR="$LFX_REPOS_DIR_OVERRIDE"
+# Then check: ls -d "$LFX_REPOS_DIR"/lfx-v2-*-service 2>/dev/null
+```
 
 **Report:**
 - Endpoint exists? (path, method, status codes)
@@ -246,4 +261,4 @@ This keeps the user informed that exploration is happening and what's being chec
 - **Be specific** — include file paths, method names, field names
 - **Flag blockers** — if an upstream API doesn't exist, say so clearly
 - **Include example content** — read and include the key sections of example files
-- **Prefer local reads** — if a Go repo exists at `~/lf/`, read it directly instead of using `gh api`
+- **Prefer local reads** — if a Go repo exists locally (auto-detected via `linuxfoundation` org remote discovery), read it directly instead of using `gh api`

--- a/lfx-test-journey/SKILL.md
+++ b/lfx-test-journey/SKILL.md
@@ -63,11 +63,50 @@ If a subcommand requires a journey name and the user didn't provide one, run **L
 
 ### Step 1: Discover Repos
 
-Scan `~/lf/` for git repositories:
+Automatically detect where `linuxfoundation` org repos are cloned, then scan for valid repos:
 
 ```bash
-for dir in ~/lf/*/; do
-  if [ -d "$dir/.git" ]; then
+# Step 0: Resolve where linuxfoundation org repos are cloned
+LFX_REPOS_DIR=""
+
+# Method 1: If currently inside a linuxfoundation repo, use its parent
+if git remote -v 2>/dev/null | grep -q 'github\.com[:/]linuxfoundation/'; then
+  LFX_REPOS_DIR="$(dirname "$(git rev-parse --show-toplevel)")"
+fi
+
+# Method 2: If not in a repo, search common parent dirs for any linuxfoundation repo
+if [ -z "$LFX_REPOS_DIR" ]; then
+  for candidate in ~/lf ~/code ~/projects ~/workspace ~/src ~/dev; do
+    if [ -d "$candidate" ]; then
+      match=$(find "$candidate" -maxdepth 2 -name .git -type d 2>/dev/null | while read gitdir; do
+        repo_dir=$(dirname "$gitdir")
+        if git -C "$repo_dir" remote -v 2>/dev/null | grep -q 'github\.com[:/]linuxfoundation/'; then
+          dirname "$repo_dir"
+          break
+        fi
+      done)
+      if [ -n "$match" ]; then
+        LFX_REPOS_DIR="$match"
+        break
+      fi
+    fi
+  done
+fi
+
+# Method 3: Override via env var (always wins if set)
+if [ -n "${LFX_REPOS_DIR_OVERRIDE:-}" ]; then
+  LFX_REPOS_DIR="$LFX_REPOS_DIR_OVERRIDE"
+fi
+
+# If still not found, ask the user via AskUserQuestion:
+# "Where are your linuxfoundation repos cloned?"
+```
+
+Once `LFX_REPOS_DIR` is resolved, scan it for repos that belong to the `linuxfoundation` org:
+
+```bash
+for dir in "$LFX_REPOS_DIR"/*/; do
+  if [ -d "$dir/.git" ] && git -C "$dir" remote -v 2>/dev/null | grep -q 'github\.com[:/]linuxfoundation/'; then
     echo "$dir"
   fi
 done
@@ -76,12 +115,12 @@ done
 Present as a numbered list and **STOP — use `AskUserQuestion` and wait for the user to respond before continuing**:
 
 ```
-Scanning ~/lf/ for git repos...
+Scanning <discovered-dir> for linuxfoundation repos...
 
 Which repos are part of this journey? (type numbers, e.g. "1, 3")
-  1. ~/lf/lfx-v2-ui
-  2. ~/lf/lfx-v2-committee-service
-  3. ~/lf/lfx-v2-meeting-service
+  1. <discovered-dir>/lfx-v2-ui
+  2. <discovered-dir>/lfx-v2-committee-service
+  3. <discovered-dir>/lfx-v2-meeting-service
 ```
 
 **⛔ GATE: You MUST call `AskUserQuestion` here and wait for the user's response. Do NOT continue to Step 2 until the user has selected repos.** Parse their response (comma-separated numbers or repo names).


### PR DESCRIPTION
## Summary

- Skills now auto-detect where `linuxfoundation` org repos are cloned by inspecting git remotes instead of assuming `~/lf/`
- Discovery chain: current repo parent → common directory scan (`~/lf`, `~/code`, `~/projects`, etc.) → `LFX_REPOS_DIR_OVERRIDE` env var → ask user
- Repo scan validates each directory has a `linuxfoundation` remote (HTTPS or SSH), rather than blindly listing everything

## Files changed

- **`lfx-test-journey/SKILL.md`** — Full discovery logic replacing hardcoded `~/lf/` scan
- **`lfx-coordinator/SKILL.md`** — Discovery snippet in Step 3 research + dynamic path in prose
- **`lfx-research/SKILL.md`** — Discovery snippet for local repo detection + updated rules
- **`README.md`** — Updated auto-discovery description

## Test plan

- [ ] `grep -rn '~/lf/' --include='*.md'` returns zero matches
- [ ] All bash discovery snippets pass `bash -n` syntax check
- [ ] Regex `github\.com[:/]linuxfoundation/` covers both HTTPS and SSH remotes
- [ ] Running from inside a `linuxfoundation` repo correctly resolves the parent directory
- [ ] `LFX_REPOS_DIR_OVERRIDE` env var takes precedence when set