### PR TITLE
[LFXV2-1303] Add indexed-data-types reference to lfx-coordinator skill

### DIFF
--- a/lfx-coordinator/SKILL.md
+++ b/lfx-coordinator/SKILL.md
@@ -52,6 +52,15 @@ Step 7: Summary — report results, suggest /lfx-preflight
 - Build order: Upstream Go service → Shared types → Express proxy → Frontend
 - **Identify which repos need changes** — if both a Go service and lfx-v2-ui are involved, plan for both
 
+## References
+
+| Topic | File |
+|-------|------|
+| All queryable resource types, which service publishes each, and how to add new fields or types | [references/indexed-data-types.md](references/indexed-data-types.md) |
+| Shared TypeScript types used across Angular and Express | [references/shared-types.md](references/shared-types.md) |
+
+Read the relevant reference before planning work that involves query service usage, indexing changes, or adding fields to indexed resources.
+
 ## Step 3: Research (do this inline — NOT via Skill delegation)
 
 Use your Read, Glob, Grep, and Bash tools to quickly check:

--- a/lfx-coordinator/references/indexed-data-types.md
+++ b/lfx-coordinator/references/indexed-data-types.md
@@ -1,0 +1,99 @@
+<!-- Copyright The Linux Foundation and each contributor to LFX. -->
+<!-- SPDX-License-Identifier: MIT -->
+
+# Queryable Resource Types in LFX V2
+
+All resource types are queryable via the query service (`lfx-v2-query-service`) using
+`GET /query/resources?v=1&type=<type>`. The query service subscribes to a shared
+OpenSearch index populated by `lfx-v2-indexer-service`, which itself subscribes to all
+`lfx.index.*` NATS subjects using a wildcard (`lfx.index.>`).
+
+**How to find all types**: check each backend service's `pkg/constants/subjects.go` (or
+equivalent) for constants of the form `"lfx.index.<type>"`. Do NOT rely solely on the
+indexer service's `ObjectType*` constants — they lag behind active publishers.
+
+---
+
+## Resource Types by Domain
+
+### Projects — `lfx-v2-project-service`
+
+| `type` | NATS subject | Source file |
+|--------|-------------|-------------|
+| `project` | `lfx.index.project` | `pkg/constants/nats.go` |
+| `project_settings` | `lfx.index.project_settings` | `pkg/constants/nats.go` |
+
+### Committees — `lfx-v2-committee-service`
+
+| `type` | NATS subject | Source file |
+|--------|-------------|-------------|
+| `committee` | `lfx.index.committee` | `pkg/constants/subjects.go` |
+| `committee_settings` | `lfx.index.committee_settings` | `pkg/constants/subjects.go` |
+| `committee_member` | `lfx.index.committee_member` | `pkg/constants/subjects.go` |
+| `committee_invite` | `lfx.index.committee_invite` | `pkg/constants/subjects.go` |
+| `committee_application` | `lfx.index.committee_application` | `pkg/constants/subjects.go` |
+
+### Meetings — `lfx-v1-sync-helper`
+
+> The meeting service (`lfx-v2-meeting-service`) is a stateless ITX proxy and does **not**
+> index data. All meeting indexing is initiated by `lfx-v1-sync-helper`, which publishes
+> to `lfx.index.*` subjects (not `lfx.v1.index.*`). The `v1_` prefix in the type name
+> reflects that the data originates from the v1 Zoom/ITX API.
+
+| `type` | NATS subject | Source file |
+|--------|-------------|-------------|
+| `v1_meeting` | `lfx.index.v1_meeting` | `cmd/lfx-v1-sync-helper/handlers_meetings.go` |
+| `v1_meeting_registrant` | `lfx.index.v1_meeting_registrant` | `cmd/lfx-v1-sync-helper/handlers_meetings.go` |
+| `v1_meeting_rsvp` | `lfx.index.v1_meeting_rsvp` | `cmd/lfx-v1-sync-helper/handlers_meetings.go` |
+| `v1_meeting_attachment` | `lfx.index.v1_meeting_attachment` | `cmd/lfx-v1-sync-helper/handlers_meetings.go` |
+| `v1_past_meeting` | `lfx.index.v1_past_meeting` | `cmd/lfx-v1-sync-helper/handlers_meetings.go` |
+| `v1_past_meeting_participant` | `lfx.index.v1_past_meeting_participant` | `cmd/lfx-v1-sync-helper/handlers_meetings.go` |
+| `v1_past_meeting_attachment` | `lfx.index.v1_past_meeting_attachment` | `cmd/lfx-v1-sync-helper/handlers_meetings.go` |
+| `v1_past_meeting_recording` | `lfx.index.v1_past_meeting_recording` | `cmd/lfx-v1-sync-helper/handlers_meetings.go` |
+| `v1_past_meeting_transcript` | `lfx.index.v1_past_meeting_transcript` | `cmd/lfx-v1-sync-helper/handlers_meetings.go` |
+| `v1_past_meeting_summary` | `lfx.index.v1_past_meeting_summary` | `cmd/lfx-v1-sync-helper/handlers_meetings.go` |
+
+### Mailing Lists — `lfx-v2-mailing-list-service`
+
+| `type` | NATS subject | Source file |
+|--------|-------------|-------------|
+| `groupsio_service` | `lfx.index.groupsio_service` | `pkg/constants/subjects.go` |
+| `groupsio_service_settings` | `lfx.index.groupsio_service_settings` | `pkg/constants/subjects.go` |
+| `groupsio_mailing_list` | `lfx.index.groupsio_mailing_list` | `pkg/constants/subjects.go` |
+| `groupsio_mailing_list_settings` | `lfx.index.groupsio_mailing_list_settings` | `pkg/constants/subjects.go` |
+| `groupsio_member` | `lfx.index.groupsio_member` | `pkg/constants/subjects.go` |
+
+### Voting — `lfx-v2-voting-service`
+
+| `type` | NATS subject | Source file |
+|--------|-------------|-------------|
+| `vote` | `lfx.index.vote` | `internal/infrastructure/eventing/nats_publisher.go` |
+| `vote_response` | `lfx.index.vote_response` | `internal/infrastructure/eventing/nats_publisher.go` |
+
+### Surveys — `lfx-v2-survey-service`
+
+| `type` | NATS subject | Source file |
+|--------|-------------|-------------|
+| `survey` | `lfx.index.survey` | `internal/infrastructure/eventing/nats_publisher.go` |
+| `survey_response` | `lfx.index.survey_response` | `internal/infrastructure/eventing/nats_publisher.go` |
+
+---
+
+## Implications for the `lfx-backend-builder`
+
+When adding indexing for a **new field** on an existing type, the change goes in the
+service that owns that type's NATS publish (see Source file column above). The pattern
+is always the same — update the `IndexingConfig` passed to `sendIndexerMessage`:
+
+- `name_and_aliases` — controls typeahead search
+- `tags` — controls tag filtering
+- `parent_refs` — controls parent navigation
+- `data` — the full resource snapshot returned in query results (include any new fields here)
+
+When adding a **new resource type**, the publishing service needs a new
+`lfx.index.<new_type>` subject constant and a corresponding `sendIndexerMessage` call.
+The indexer picks it up automatically via its wildcard subscription — no indexer changes
+needed.
+
+For query service usage details (API parameters, access control, CEL filters), see
+`lfx-backend-builder/references/query-service.md`.


### PR DESCRIPTION
## Summary

- Add `lfx-coordinator/references/indexed-data-types.md` documenting all 27 queryable resource types in the LFX V2 system, grouped by domain with their NATS subjects and source files
- Update `lfx-coordinator/SKILL.md` with a References table so the coordinator knows to consult this file when planning work involving indexing or the query service

## Example

I prompted the lfx-coordinator after adding this skill reference:

```
> /lfx-coordinator I want to make an update to the UI, but I want to know if it's possible with the existing data. I want to create a section on the committee page that shows committee contributors. Do we have that data?

The short answer: no, that data doesn't exist yet.

  Here's what the committee service does have:

  - committee_member — people formally added to a committee, each with a role (Chair, Lead, Vice Chair, Secretary, Treasurer, Director, Counsel, Developer Seat, TAC/TOC Representative, LF Staff, None)
  - Invites and Applications — pending membership

  There's no "contributor" concept anywhere in the system — not as a role, not as a separate resource type, not in the query service index. The closest adjacent data that could indicate contribution activity would be meeting participants (v1_past_meeting_participant) or
   vote/survey responses, but those aren't linked back to a committee directly in a way that would power a contributors section.

  To build this, you'd first need to define what a "contributor" is. A few directions:

  1. Reuse committee_member — treat members as contributors (they already exist, this is buildable today)
  2. Meeting participation — people who attended committee-linked meetings (data exists in v1_past_meeting_participant, but the parent relationship to a committee would need to be verified)
  3. New concept — define contributors as a distinct category in the committee service (would require new backend work)

  Which of these did you have in mind, or is this something that still needs to be scoped?
```

Here is another chat with Claude after adding the skill reference and restarting the Claude session.

```
❯ /lfx I want to create a new UI feature. Tell me what data exists so I know what are the constraints for a new UI feature.                                                                                                                                                   
                                                                                                                            
⏺ Bash(if [ -f apps/lfx-one/angular.json ] || [ -f turbo.json ]; then echo "REPO_TYPE=angular"; elif [ -f go.mod ]; then echo "REPO_TYPE=go"; else echo "REPO_TYPE=unkn…)                                                                                                     
  ⎿  REPO_TYPE=unknown                                                                                                                                                                                                                                                      
     feat/LFXV2-1303-indexed-data-types-reference                                                                                                                                                                                                                             
     ?? lfx-backend-builder/lfx-backend-builder                                                                                                                                                                                                                               
     … +5 lines (ctrl+o to expand)                                                                                                                                                                                                                                            
                                                                                                                                                                                                                                                                              
⏺ You're in the skills repo (not an LFX application repo directly), on branch feat/LFXV2-1303-indexed-data-types-reference. That branch name suggests you're working with indexed data types in the LFX v2 / query service area.                                              
                                                                                                                                                                                                                                                                              
  Since you want to understand what data exists before building a UI feature, this is a research task — let me route you to the right skill.                                                                                                                                  
   
⏺ Skill(lfx-research)                                                                                                                                                                                                                                                         
  ⎿  Successfully loaded skill · 6 tools allowed
                                                                                                                                                                                                                                                                              
⏺ Checking local LFX repos and JIRA ticket for context...
                                                                                                                                                                                                                                                                              
  Read 1 file (ctrl+o to expand)                                                                                                                                                                                                                                              
                                                                                                                                                                                                                                                                              
⏺ claude.ai Atlassian - Get issue (MCP)(cloudId: "linuxfoundation.atlassian.net", issueIdOrKey: "LFXV2-1303", responseContentFormat: "markdown")                                                                                                                              
  ⎿  {                                                                                                                                                                                                                                                                        
       "issues": {                                                                        
         "totalCount": 1,                                                                                                                                                                                                                                                     
     … +42 lines (ctrl+o to expand)                                                                                                                                                                                                                                           
                                                                                                                                                                                                                                                                              
⏺ Bash(gh api repos/linuxfoundation/lfx-v2-query-service/contents/ --jq '.[].name' 2>/dev/null | head -30)                                                                                                                                                                    
  ⎿  .github                                                                                                                                                                                                                                                                  
     .gitignore            
     .ko.yaml                                                                                                                                                                                                                                                                 
     … +19 lines (ctrl+o to expand)                                                       
                                                                                                                                                                                                                                                                              
⏺ Reading the indexed-data-types reference created in this branch, and exploring the query service design...                                                                                                                                                                  
                                                                                                                                                                                                                                                                              
  Searched for 1 pattern (ctrl+o to expand)                                                                                                                                                                                                                                   
                                                                                                                                                                                                                                                                              
⏺ Bash(gh api repos/linuxfoundation/lfx-v2-query-service/contents/design --jq '.[].name' 2>/dev/null)                                                                                                                                                                         
  ⎿  query-svc.go                                                                                                                                                                                                                                                             
     types.go                                                                                                                                                                                                                                                               
                                                                                                                                                                                                                                                                              
  Read 1 file (ctrl+o to expand)                                                                                                                                                                                                                                              
                                                                                                                                                                                                                                                                              
⏺ Bash(gh api repos/linuxfoundation/lfx-v2-query-service/contents/design/query-svc.go --jq '.content' | base64 -d 2>/dev/null | head -200)                                                                                                                                    
  ⎿  // Copyright The Linux Foundation and each contributor to LFX.                                                                                                                                                                                                           
     // SPDX-License-Identifier: MIT                                                                                                                                                                                                                                          
     … +68 lines (ctrl+o to expand)                                                                                                                                                                                                                                           
                                                                                                                                                                                                                                                                              
⏺ Reading the resource type definitions and backend-builder query service reference...                                                                                                                                                                                        
                                                                                                                                                                                                                                                                              
⏺ Bash(gh api repos/linuxfoundation/lfx-v2-query-service/contents/design/types.go --jq '.content' | base64 -d 2>/dev/null)                                                                                                                                                    
  ⎿  // Copyright The Linux Foundation and each contributor to LFX.                                                                                                                                                                                                           
     // SPDX-License-Identifier: MIT                                                                                                                                                                                                                                          
     … +95 lines (ctrl+o to expand)                                                                                                                                                                                                                                           
                                                                                                                                                                                                                                                                            
  Searched for 1 pattern, read 1 file (ctrl+o to expand)                                                                                                                                                                                                                      
                                                                                                                                                                                                                                                                            
⏺ Reading the shared types reference for completeness...
                                                                                                                                                                                                                                                                              
  Read 1 file (ctrl+o to expand)                                                          
                                                                                                                                                                                                                                                                              
⏺ Research Findings                                                                                                                                                                                                                                                           
                                                                                                                                                                                                                                                                              
  Here's a complete picture of what data exists and the constraints for building a new UI feature:                                                                                                                                                                            
                                                                                                                                                                                                                                                                              
  ---                                                                                                                                                                                                                                                                         
  All 27 Queryable Resource Types                                                                                                                                                                                                                                             
                                                                                                                                                                                                                                                                              
  Everything is accessed via one endpoint: GET /query/resources?v=1&type=<type>                                                                                                                                                                                               
                                                                                                                                                                                                                                                                              
  ┌───────────────┬─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┐                     
  │    Domain     │                                                                                                           Resource Types                                                                                                            │                     
  ├───────────────┼─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┤                     
  │ Projects      │ project, project_settings                                                                                                                                                                                                           │
  ├───────────────┼─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┤                     
  │ Committees    │ committee, committee_settings, committee_member, committee_invite, committee_application                                                                                                                                            │                     
  ├───────────────┼─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┤                     
  │ Meetings      │ v1_meeting, v1_meeting_registrant, v1_meeting_rsvp, v1_meeting_attachment, v1_past_meeting, v1_past_meeting_participant, v1_past_meeting_attachment, v1_past_meeting_recording, v1_past_meeting_transcript, v1_past_meeting_summary │                     
  ├───────────────┼─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┤                     
  │ Mailing Lists │ groupsio_service, groupsio_service_settings, groupsio_mailing_list, groupsio_mailing_list_settings, groupsio_member                                                                                                                 │
  ├───────────────┼─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┤                     
  │ Voting        │ vote, vote_response                                                                                                                                                                                                                 │
  ├───────────────┼─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┤                     
  │ Surveys       │ survey, survey_response                                                                                                                                                                                                             │
  └───────────────┴─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘                     
                           
  ---                                                                                                                                                                                                                                                                         
  How You Query Data From the UI
                                                                                                                                                                                                                                                                              
  The query service supports these filters — all combinable:
                                                                                                                                                                                                                                                                              
  ┌───────────────────────────────────────────────┬───────────────────────────────────────────────────────────────┐                                                                                                                                                           
  │                     What                      │                              How                              │                                                                                                                                                           
  ├───────────────────────────────────────────────┼───────────────────────────────────────────────────────────────┤                                                                                                                                                           
  │ By type                                       │ type=committee                                                │
  ├───────────────────────────────────────────────┼───────────────────────────────────────────────────────────────┤                                                                                                                                                           
  │ By name / typeahead                           │ name=gov board                                                │                                                                                                                                                           
  ├───────────────────────────────────────────────┼───────────────────────────────────────────────────────────────┤                                                                                                                                                           
  │ By parent (e.g. all committees for a project) │ parent=project:uuid                                           │                                                                                                                                                           
  ├───────────────────────────────────────────────┼───────────────────────────────────────────────────────────────┤                                                                                                                                                           
  │ By tag (OR logic)                             │ tags=active&tags=public                                       │
  ├───────────────────────────────────────────────┼───────────────────────────────────────────────────────────────┤                                                                                                                                                           
  │ By tag (AND logic)                            │ tags_all=governance&tags_all=security                         │
  ├───────────────────────────────────────────────┼───────────────────────────────────────────────────────────────┤                                                                                                                                                           
  │ By exact field in data                        │ filters=status:active                                         │
  ├───────────────────────────────────────────────┼───────────────────────────────────────────────────────────────┤                                                                                                                                                           
  │ By date range                                 │ date_field=updated_at&date_from=2025-01-01&date_to=2025-12-31 │
  ├───────────────────────────────────────────────┼───────────────────────────────────────────────────────────────┤                                                                                                                                                           
  │ By CEL expression                             │ cel_filter=data.slug == "tlf"                                 │
  ├───────────────────────────────────────────────┼───────────────────────────────────────────────────────────────┤                                                                                                                                                           
  │ Sort                                          │ sort=name_asc | name_desc | updated_asc | updated_desc        │
  ├───────────────────────────────────────────────┼───────────────────────────────────────────────────────────────┤                                                                                                                                                           
  │ Pagination                                    │ page_size=50&page_token=<opaque>                              │
  ├───────────────────────────────────────────────┼───────────────────────────────────────────────────────────────┤                                                                                                                                                           
  │ Count only                                    │ GET /query/resources/count                                    │
  └───────────────────────────────────────────────┴───────────────────────────────────────────────────────────────┘                                                                                                                                                           
                           
  ---                                                                                                                                                                                                                                                                         
  Response Shape           
                
  Each resource comes back as a generic envelope — the data field is the raw resource snapshot:
                                                                                                                                                                                                                                                                              
  { "type": "committee", "id": "uuid", "data": { ...any fields the backend indexed... } }
                                                                                                                                                                                                                                                                              
  The data fields are schema-free — whatever each backend service put into its IndexingConfig.data. There's no guaranteed schema per type documented in the query service itself; you need to check each service's domain model.                                              
                                                                                                                                                                                                                                                                              
  ---                                                                                                                                                                                                                                                                         
  Key Constraints for UI Feature Design
                                                                                                                                                                                                                                                                              
  1. Access control is automatic — authenticated users only see resources they have permission to view (FGA-checked). Anonymous users only see resources marked public: true.
  2. data fields are opaque — the query service doesn't know the schema. To know what fields are available on e.g. committee_member, you need to look at lfx-v2-committee-service's domain model and its IndexingConfig.                                                      
  3. Meeting data comes from v1 sync — not the meeting service directly. Fields may reflect legacy Zoom/ITX data shapes.                                                                                                                                                      
  4. CEL filter is in-process — it runs after OpenSearch, which means it doesn't help with pagination performance. Use filters= or tags= for large datasets.                                                                                                                  
  5. No cross-type joins — you can't query "all committees and their members" in one call. Each type is a separate query.                                                                                                                                                     
                                                                                                                                                                                                                                                                              
  ---                                                                                                                                                                                                                                                                         
  What To Do Next                                                                                                                                                                                                                                                             
                                                                                                                                                                                                                                                                              
  Would you like to:       
  - Build the feature — I can route you to /lfx-coordinator with your specific domain and field requirements                                                                                                                                                                  
  - Dig into specific field schemas — I can look at a specific service's domain model (e.g., what fields are on committee_member.data)                                                                                                                                        
  - Understand the architecture — route to /lfx-product-architect for a deeper design discussion                                                                                                                                                                              
                                                                                                                                                                                                                                                                              
  What domain or data type is your feature focused on?
```

## Ticket

[LFXV2-1303](https://linuxfoundation.atlassian.net/browse/LFXV2-1303)

🤖 Generated with [Claude Code](https://claude.ai/code)

[LFXV2-1303]: https://linuxfoundation.atlassian.net/browse/LFXV2-1303?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ