### PR TITLE
feat(lfx-git-setup): add interactive Git DCO and GPG signing setup guide

### DIFF
--- a/lfx-git-setup/SKILL.md
+++ b/lfx-git-setup/SKILL.md
@@ -21,10 +21,10 @@ allowed-tools: Bash, Read, Glob, Grep, AskUserQuestion, WebFetch
 This skill walks contributors through two essential git contribution
 requirements used across linux foundation projects:
 
-1. **DCO signoff** (`--signoff` / `-s`) — adds a `signed-off-by: your name
-<email>` line to every commit, certifying you wrote the code and have the right
-   to contribute it under the project's license. This is a legal agreement, not
-   just a formality.
+1. **DCO signoff** (`--signoff` / `-s`) — adds a 
+  `Signed-off-by: your name <email>` line to every commit, certifying you wrote
+  the code and have the right to contribute it under the project's license. This
+  is a legal agreement, not just a formality.
 2. **GPG signed commits** (`-S`) — cryptographically signs each commit with your
    personal GPG key so GitHub can display a green "verified" badge, proving the
    commit genuinely came from you.
@@ -56,7 +56,7 @@ The end goal is a `~/.gitconfig` that looks roughly like this:
     signingkey = abc123def456  # your gpg key id
 
 [commit]
-    gpgSign = true             # auto-sign every commit with -s
+    gpgSign = true             # auto-sign every commit with -S (GPG signing)
 
 [tag]
     gpgSign = true             # auto-sign tags too
@@ -119,9 +119,9 @@ mkdir -p ~/.git-hooks
 # create the hook script
 cat > ~/.git-hooks/prepare-commit-msg << 'eof'
 #!/bin/sh
-# Auto-add DCO signed-off-by line
-sob=$(git var git_author_ident | sed -n 's/^\(.*>\).*$/signed-off-by: \1/p')
-grep -qs "^$sob" "$1" || echo "$sob" >> "$1"
+# Auto-add DCO Signed-off-by line
+sob=$(git var git_author_ident | sed -n 's/^\(.*>\).*$/Signed-off-by: \1/p')
+grep -Fqs "^$sob" "$1" || echo "$sob" >> "$1"
 eof
 
 # Make the git hook executable

--- a/lfx-git-setup/references/linux.md
+++ b/lfx-git-setup/references/linux.md
@@ -170,8 +170,8 @@ source ~/.zshrc
 mkdir -p ~/.gnupg
 chmod 700 ~/.gnupg
 
-# Set a passphrase cache timeout (86400 = 24 hours, adjust as you like)
-cat >> ~/.gnupg/gpg-agent.conf << 'EOF'
+# Set a passphrase cache timeout if not already set (86400 = 24 hours, adjust as you like)
+grep -q "default-cache-ttl" ~/.gnupg/gpg-agent.conf 2>/dev/null || cat >> ~/.gnupg/gpg-agent.conf << 'EOF'
 default-cache-ttl 86400
 max-cache-ttl 86400
 EOF
@@ -301,6 +301,8 @@ export GPG_TTY=${SSH_TTY:-$(tty)}
 #### "gpg: WARNING: unsafe permissions on homedir '/home/user/.gnupg'"
 
 ```bash
-chmod 700 ~/.gnupg
-chmod 600 ~/.gnupg/*
+# 700 on directories
+find ~/.gnupg -type d -exec chmod 700 {} \;
+# 600 on files
+find ~/.gnupg -type f -exec chmod 600 {} \;
 ```

--- a/lfx-git-setup/references/mac.md
+++ b/lfx-git-setup/references/mac.md
@@ -1,7 +1,7 @@
 <!-- Copyright The Linux Foundation and each contributor to LFX. -->
 <!-- SPDX-License-Identifier: MIT -->
 
-# MacOS: GPG + DCO Git Setup Guide
+# macOS: GPG + DCO Git Setup Guide
 
 This guide walks you through setting up GPG-signed commits and DCO signoff on
 macOS. You'll use **Homebrew** (the standard macOS package manager) and
@@ -235,7 +235,7 @@ And the commit message body should contain:
 Signed-off-by: Your Name <you@example.com>
 ```
 
-## Troubleshooting on MacOS
+## Troubleshooting on macOS
 
 ### Common Issues
 

--- a/lfx-git-setup/references/windows.md
+++ b/lfx-git-setup/references/windows.md
@@ -140,23 +140,27 @@ git config --global user.email "your-github-email@example.com"
 
 ### 3.4 Point Git at the correct gpg executable
 
-On Windows, Git may not find `gpg` automatically. Check where Gpg4win
-installed it:
+On Windows, Git may not find `gpg` automatically. In **Git Bash**, locate
+the Gpg4win installation with:
 
 ```bash
-where gpg
+command -v gpg
 ```
+
+> **Note:** `where gpg` is a CMD built-in and may not be available in Git
+> Bash. Use `where.exe gpg` if you need the Windows equivalent, or stick with
+> `command -v gpg` in Git Bash.
 
 A common path is `C:/Program Files (x86)/GnuPG/bin/gpg.exe`. Tell Git:
 
 ```bash
-git config --global gpg.program "C:/Program Files (x86)/GnuPG/bin/gpg.exe"
+git config --global gpg.program "$(command -v gpg)"
 ```
 
-Or if you're using Git Bash, use a Unix-style path resolver:
+Or if you know the exact path, set it explicitly:
 
 ```bash
-git config --global gpg.program "$(command -v gpg)"
+git config --global gpg.program "C:/Program Files (x86)/GnuPG/bin/gpg.exe"
 ```
 
 ### 3.5 Verify ~/.gitconfig
@@ -231,7 +235,7 @@ git log --show-signature -1
 #### "gpg: signing failed: No secret key"
 
 Make sure the `gpg.program` path in `.gitconfig` is correct and points to the
-Gpg4win installation. Run `where gpg` in Git Bash to confirm the path.
+Gpg4win installation. Run `command -v gpg` in Git Bash to confirm the path.
 
 #### Passphrase prompt never appears
 


### PR DESCRIPTION
## Summary

Adds a new `lfx-git-setup` skill that walks LFX contributors through configuring Git for DCO signoff and GPG-signed commits.

## What's Included

- **`lfx-git-setup/SKILL.md`** — Main skill file with trigger phrases, overall workflow, DCO signoff options (manual, alias, global hook), troubleshooting quick reference, and communication style guidance
- **`lfx-git-setup/references/mac.md`** — macOS setup guide (Homebrew + GPG Suite paths)
- **`lfx-git-setup/references/linux.md`** — Linux setup guide (Ubuntu, Fedora, Arch, openSUSE)
- **`lfx-git-setup/references/windows.md`** — Windows setup guide (native Gpg4win + WSL2 recommendation)

## How It Works

The skill is purely instructional — it reads the appropriate platform reference file and guides the user through four phases:

1. **Prerequisites** — Install GPG tools, verify Git version
2. **Generate GPG key** — Create a signing key with the user's GitHub-verified email
3. **Configure Git** — Wire the key into `~/.gitconfig` with auto-signing
4. **Register with GitHub** — Upload the public key so commits show as Verified

It also covers DCO signoff setup with three options (manual flags, git alias, global commit hook).

## Changes Since Previous Draft

- Fixed `gpgsign` → `gpgSign` (camelCase) consistently across all files to match Git's official documentation
- Fixed `-s` → `-S` for GPG signing flag throughout `SKILL.md` (lowercase `-s` is DCO signoff; uppercase `-S` is GPG signing)
- Fixed `gpg_tty` → `GPG_TTY` (env var names are case-sensitive) in troubleshooting table
- Standardized passphrase guidance to "optional, but recommended" across all platform guides
- Replaced `echo >` / `echo >>` for `gpg-agent.conf` with an idempotent `grep -q || echo >>` guard to prevent duplicate entries and data loss
- Added backup warning in mac.md troubleshooting before any destructive config reset

## Notes

- All files pass `markdownlint` cleanly
- Works for both technical and non-technical users (skill adjusts tone based on context)

🤖 Generated with [Claude Code](https://claude.ai/code)