### PR TITLE
Fix basename usage in install.sh script

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -25,7 +25,7 @@ failed=0
 for skill_path in "$SCRIPT_DIR"/lfx-*/ "$SCRIPT_DIR"/lfx/; do
   [ -d "$skill_path" ] || continue
 
-  skill_name="$(basename "$skill_path")"
+  skill_name="$(basename "${skill_path%/}")"
   target="$SKILLS_DIR/$skill_name"
 
   if [ -L "$target" ]; then


### PR DESCRIPTION
basename on a directory with a trailing '/' results in an empty value.
This change updates the '$skill_path' variable passed to basename to
include '%/' to strip any trailing slashes if they exist.

Signed-off-by: Trevor Bramwell <tbramwell@linuxfoundation.org>
