### PR TITLE
[LFXV2-1607] Update lfx-backend-builder to use generic fga-sync subjects

### DIFF
--- a/lfx-backend-builder/references/fga-patterns.md
+++ b/lfx-backend-builder/references/fga-patterns.md
@@ -42,11 +42,11 @@ Publish to `lfx.fga-sync.update_access` using the `GenericFGAMessage` envelope:
 ```
 
 The `references.project` field is how fga-sync establishes the parent link in OpenFGA.
-It writes a tuple like `project:{uid}#project@committee:{uid}`, enabling permission
-inheritance from the parent project.
+It writes a tuple like `project:{project_uid}#project@committee:{committee_uid}`, enabling
+permission inheritance from the parent project.
 
-`references` values can be bare UIDs (handler prepends `{type}:`) or full `type:uid`
-strings — both are accepted.
+`references` values can be bare UIDs (handler prepends the map key as the type prefix,
+e.g. `"project": ["abc"]` → `project:abc`) or full `type:uid` strings — both are accepted.
 
 ## Access Message Format (delete)
 

--- a/lfx-backend-builder/references/fga-patterns.md
+++ b/lfx-backend-builder/references/fga-patterns.md
@@ -21,19 +21,22 @@ Examples:
 
 ## Access Message Format (create/update)
 
-Publish to `lfx.update_access.{resource_type}`:
+Publish to `lfx.fga-sync.update_access` using the `GenericFGAMessage` envelope:
 
 ```json
 {
-  "uid": "resource-uuid",
   "object_type": "committee",
-  "public": false,
-  "relations": {
-    "writer": ["user:alice"],
-    "auditor": ["user:bob"]
-  },
-  "references": {
-    "project": "parent-project-uuid"
+  "operation": "update_access",
+  "data": {
+    "uid": "resource-uuid",
+    "public": false,
+    "relations": {
+      "writer": ["alice"],
+      "auditor": ["bob"]
+    },
+    "references": {
+      "project": ["parent-project-uuid"]
+    }
   }
 }
 ```
@@ -42,13 +45,21 @@ The `references.project` field is how fga-sync establishes the parent link in Op
 It writes a tuple like `project:{uid}#project@committee:{uid}`, enabling permission
 inheritance from the parent project.
 
+`references` values can be bare UIDs (handler prepends `{type}:`) or full `type:uid`
+strings — both are accepted.
+
 ## Access Message Format (delete)
 
-Publish to `lfx.delete_all_access.{resource_type}` with the plain UID as the message body
-(not JSON — just the string):
+Publish to `lfx.fga-sync.delete_access` using the `GenericFGAMessage` envelope:
 
-```text
-"abc-123-uuid"
+```json
+{
+  "object_type": "committee",
+  "operation": "delete_access",
+  "data": {
+    "uid": "abc-123-uuid"
+  }
+}
 ```
 
 fga-sync will purge all OpenFGA tuples for that object.
@@ -101,7 +112,7 @@ it, making all older cached entries stale.
 
 If you suspect stale cache results, look for `"cache invalidation failed"` in fga-sync logs.
 
-## Publishing Access Messages — Generic vs Custom Handler
+## Publishing Access Messages — Go Code Examples
 
 fga-sync has **generic handlers** that work with any resource type. You do **not** need
 to add a new handler in fga-sync for a new resource type. Publish to the generic subjects:
@@ -178,11 +189,6 @@ GenericFGAMessage{ObjectType: "committee", Operation: "member_remove",
 
 `member_put` is idempotent and supports `mutually_exclusive_with` for role transitions.
 See `lfx-v2-fga-sync/docs/client-guide.md` for the full reference.
-
-### Custom handlers
-
-Only add a resource-specific handler in fga-sync (e.g. `handler_sponsorship.go`) if the
-generic message format cannot express the required logic. Prefer the generic subjects.
 
 ### OpenFGA authorization model
 

--- a/lfx-backend-builder/references/nats-messaging.md
+++ b/lfx-backend-builder/references/nats-messaging.md
@@ -15,8 +15,10 @@ The general patterns:
 | Pattern | Purpose | Example |
 |---|---|---|
 | `lfx.index.{resource_type}` | Publish to indexer-service | `lfx.index.committee` |
-| `lfx.update_access.{resource_type}` | Publish access update to fga-sync | `lfx.update_access.committee` |
-| `lfx.delete_all_access.{resource_type}` | Publish access delete to fga-sync | `lfx.delete_all_access.committee` |
+| `lfx.fga-sync.update_access` | Publish access update to fga-sync | `lfx.fga-sync.update_access` |
+| `lfx.fga-sync.delete_access` | Publish access delete to fga-sync | `lfx.fga-sync.delete_access` |
+| `lfx.fga-sync.member_put` | Add a user relation via fga-sync | `lfx.fga-sync.member_put` |
+| `lfx.fga-sync.member_remove` | Remove a user relation via fga-sync | `lfx.fga-sync.member_remove` |
 | `lfx.{service-api}.{operation}` | Service-to-service request/reply | `lfx.committee-api.get_name` |
 
 ### Examples from the codebase
@@ -39,7 +41,7 @@ Not every write requires both an index message and an access message:
 | Message | When to send |
 |---|---|
 | **Index message** (`lfx.index.*`) | Always — on every create, update, delete |
-| **Access message** (`lfx.update_access.*` / `lfx.delete_all_access.*`) | Only when the resource has its own FGA type |
+| **Access message** (`lfx.fga-sync.update_access` / `lfx.fga-sync.delete_access`) | Only when the resource has its own FGA type |
 
 For example, `committee` has its own FGA type so it needs both messages. But
 `meeting_rsvp` has no FGA type — it only gets an index message, and access is


### PR DESCRIPTION
## Summary

- Replace legacy `lfx.update_access.*` and `lfx.delete_all_access.*` subject references in `nats-messaging.md` and `fga-patterns.md` with the generic `lfx.fga-sync.*` subjects
- Update access message format examples to show the `GenericFGAMessage` envelope (`object_type`, `operation`, `data`)
- Remove the "Custom handlers" note since legacy resource-specific handlers no longer exist in fga-sync (removed in LFXV2-1607)

## Ticket

[LFXV2-1607](https://linuxfoundation.atlassian.net/browse/LFXV2-1607)

🤖 Generated with [Claude Code](https://claude.ai/code)

[LFXV2-1607]: https://linuxfoundation.atlassian.net/browse/LFXV2-1607?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ