### PR TITLE
[LFXV2-1608] docs: remove enricher system references

### DIFF
--- a/lfx-backend-builder/references/getting-started.md
+++ b/lfx-backend-builder/references/getting-started.md
@@ -38,7 +38,7 @@ Own a specific resource type and expose a REST API:
 | Repo | Resource |
 | --- | --- |
 | `lfx-v2-committee-service` | Committee (native — use as template for new native services) |
-| `lfx-v2-project-service` | Project (native — deprecated enricher pattern, do not use as template) |
+| `lfx-v2-project-service` | Project (native) |
 | `lfx-v2-meeting-service` | Meeting (wrapper → ITX) |
 | `lfx-v2-voting-service` | Vote (wrapper → ITX, use as template for new wrapper services) |
 | `lfx-v2-survey-service` | Survey (wrapper → ITX) |

--- a/lfx-backend-builder/references/indexer-patterns.md
+++ b/lfx-backend-builder/references/indexer-patterns.md
@@ -48,10 +48,7 @@ constants.ActionDeleted  // "deleted"
 ## IndexingConfig — the Current Pattern
 
 `IndexingConfig` is how a resource service provides all the metadata the indexer needs to
-build a well-structured OpenSearch document. **All new services must include it.**
-
-Without `IndexingConfig`, the indexer falls back to resource-specific "enrichers" — that
-is the old, deprecated pattern still used by `project-service`. Do not follow it.
+build a well-structured OpenSearch document. **All services must include it — messages without it are rejected by the indexer.**
 
 ```go
 type IndexingConfig struct {
@@ -113,7 +110,7 @@ msg := indexerTypes.IndexerMessageEnvelope{
 
 1. Parses the `IndexerMessageEnvelope` from the NATS payload
 2. If `IndexingConfig` is present: builds the OpenSearch document directly from it (generic path)
-3. If `IndexingConfig` is absent: looks up a resource-specific enricher by object type (deprecated path)
+3. If `IndexingConfig` is absent: rejects the message with an error
 4. Inserts a new document with `latest: true`
 5. A background janitor later sets `latest: false` on old versions
 

--- a/lfx-backend-builder/references/service-types.md
+++ b/lfx-backend-builder/references/service-types.md
@@ -20,8 +20,7 @@ Examples: `lfx-v2-project-service`, `lfx-v2-committee-service`
 | NATS publishing | Both index + access messages on every write |
 | Template | `lfx-v2-committee-service` (newest — use this) |
 
-> **Do not use `project-service` as a template.** It uses the deprecated enricher pattern
-> for indexing. `committee-service` is the correct reference.
+> Use `lfx-v2-committee-service` as the template for new native services.
 
 ### Key structures
 

--- a/lfx-product-architect/SKILL.md
+++ b/lfx-product-architect/SKILL.md
@@ -91,7 +91,7 @@ The LFX Self-Service platform consists of:
 | Repo | Resource | Type |
 |------|----------|------|
 | `lfx-v2-committee-service` | Committee | Native (template for new native services) |
-| `lfx-v2-project-service` | Project | Native (deprecated enricher — do NOT use as template) |
+| `lfx-v2-project-service` | Project | Native |
 | `lfx-v2-meeting-service` | Meeting | Wrapper -> ITX |
 | `lfx-v2-voting-service` | Vote | Wrapper -> ITX (template for new wrapper services) |
 | `lfx-v2-survey-service` | Survey | Wrapper -> ITX |


### PR DESCRIPTION
## Summary

The indexer enricher system has been fully removed. Publishers now supply `IndexingConfig` directly and messages without it are rejected. Updated skill docs to reflect the current design:

- `lfx-product-architect/SKILL.md` — project-service row: removed "deprecated enricher" note, now just "Native"
- `lfx-backend-builder/references/indexer-patterns.md` — removed enricher fallback description; updated indexer flow step 3 to state messages without `IndexingConfig` are rejected
- `lfx-backend-builder/references/getting-started.md` — project-service row: removed enricher pattern note
- `lfx-backend-builder/references/service-types.md` — removed enricher warning block and table note

## Ticket

[LFXV2-1608](https://jira.linuxfoundation.org/browse/LFXV2-1608)

🤖 Generated with [Claude Code](https://claude.ai/code)

[LFXV2-1608]: https://linuxfoundation.atlassian.net/browse/LFXV2-1608?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ