### PR TITLE
fix(license): standardize markdown license headers across skills and agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+<!-- Copyright The Linux Foundation and each contributor to LFX. -->
+<!-- SPDX-License-Identifier: MIT -->
+
 # LFX Skills
 
 Central Claude Code plugin for LFX development. Bundles the canonical LFX architecture knowledge, cross-repo workflow skills, and post-commit reviewer agents that every LFX contributor needs. Each LFX repo's local setup (`CLAUDE.md`, `.claude/rules/`, `.claude/skills/`, and repo-owned `docs/`) calls out to this plugin for cross-repo topology, platform conventions, and review automation.

--- a/agents/lfx-committee-service-code-reviewer.md
+++ b/agents/lfx-committee-service-code-reviewer.md
@@ -3,6 +3,8 @@ name: lfx-committee-service-code-reviewer
 description: "Post-commit code-convention audit for lfx-v2-committee-service. Audits the latest commit in the lfx-v2-committee-service repo against the repo documented rule surface: CLAUDE.md, repo-local committee-service skills, README/docs, Goa design/generated-code boundaries, NATS/FGA/indexer contracts, service chart wiring, and code conventions. May be launched from the LFX workspace root, but always operates in lfx-v2-committee-service. Every repo-convention finding quotes a loaded source. Pass the keyword `branch` to switch to full-branch mode against origin/main for the pre-PR sweep."
 model: opus
 ---
+<!-- Copyright The Linux Foundation and each contributor to LFX. -->
+<!-- SPDX-License-Identifier: MIT -->
 
 # LFX Committee Service Code Reviewer
 

--- a/agents/lfx-committee-service-learnings-reviewer.md
+++ b/agents/lfx-committee-service-learnings-reviewer.md
@@ -3,6 +3,8 @@ name: lfx-committee-service-learnings-reviewer
 description: "Post-commit empirical-pattern review for lfx-v2-committee-service. Audits the latest commit in the lfx-v2-committee-service repo against `docs/reviews/knowledge-base/` — patterns extracted from past PR review comments on this repo. May be launched from the LFX workspace root, but always operates in `lfx-v2-committee-service`. Findings are gated by KB matches: every finding must quote a pattern entry; unsourced findings are dropped. Pass the keyword `branch` to switch to full-branch mode (audits the branch's diff against origin/main — used for the pre-PR full-branch sweep). Renders a markdown review. Invoke after every commit while pre-PR, in parallel with `lfx-skills:lfx-committee-service-code-reviewer`."
 model: opus
 ---
+<!-- Copyright The Linux Foundation and each contributor to LFX. -->
+<!-- SPDX-License-Identifier: MIT -->
 
 # LFX Committee Service Learnings Reviewer
 

--- a/agents/lfx-email-service-code-reviewer.md
+++ b/agents/lfx-email-service-code-reviewer.md
@@ -3,6 +3,8 @@ name: lfx-email-service-code-reviewer
 description: "Post-commit code-convention audit for lfx-v2-email-service. Audits the latest commit in the email service repo against the repo-owned documented rule surface: CLAUDE.md, .claude/skills/email-service-dev, pr-readiness/preflight boundaries, README/docs, public pkg/api contract, cmd/internal layout, Makefile, and chart docs. May be launched from the LFX workspace root, but always operates in lfx-v2-email-service. Every repo-convention finding quotes a loaded source. Pass the keyword `branch` to switch to full-branch mode (audits origin/main...HEAD). Invoke after every pre-PR commit in parallel with lfx-skills:lfx-general-code-reviewer."
 model: opus
 ---
+<!-- Copyright The Linux Foundation and each contributor to LFX. -->
+<!-- SPDX-License-Identifier: MIT -->
 
 # LFX Email Service Code Reviewer
 

--- a/agents/lfx-email-service-learnings-reviewer.md
+++ b/agents/lfx-email-service-learnings-reviewer.md
@@ -3,6 +3,8 @@ name: lfx-email-service-learnings-reviewer
 description: "Post-commit empirical-pattern review for lfx-v2-email-service. Audits the latest commit in the lfx-v2-email-service repo against `docs/reviews/knowledge-base/` — patterns extracted from past PR review comments on this repo. May be launched from the LFX workspace root, but always operates in `lfx-v2-email-service`. Findings are gated by KB matches: every finding must quote a pattern entry; unsourced findings are dropped. Pass the keyword `branch` to switch to full-branch mode (audits the branch's diff against origin/main — used for the pre-PR full-branch sweep). Renders a markdown review. Invoke after every commit while pre-PR, in parallel with `lfx-skills:lfx-email-service-code-reviewer`."
 model: opus
 ---
+<!-- Copyright The Linux Foundation and each contributor to LFX. -->
+<!-- SPDX-License-Identifier: MIT -->
 
 # LFX Email Service Learnings Reviewer
 

--- a/agents/lfx-general-code-reviewer.md
+++ b/agents/lfx-general-code-reviewer.md
@@ -4,6 +4,8 @@ description: "General post-commit code reviewer for LFX repos. Reviews the lates
 model: opus
 color: pink
 ---
+<!-- Copyright The Linux Foundation and each contributor to LFX. -->
+<!-- SPDX-License-Identifier: MIT -->
 
 You are a senior code reviewer with deep expertise in software quality, security, and maintainability. You have extensive experience across multiple programming languages and frameworks, with particular strength in identifying subtle bugs, security vulnerabilities, and architectural issues. Your reviews are known for being thorough yet pragmatic—you catch real issues while respecting the developer's time.
 

--- a/agents/lfx-member-service-code-reviewer.md
+++ b/agents/lfx-member-service-code-reviewer.md
@@ -3,6 +3,8 @@ name: lfx-member-service-code-reviewer
 description: "Post-commit code-convention audit for lfx-v2-member-service. Audits the latest commit in the lfx-v2-member-service repo against the repo-owned documented rule surface: CLAUDE.md, local member-service skills, ARCHITECTURE.md, README/docs, Salesforce/cache docs, NATS integration guidance, chart docs/templates, and Makefile. May be launched from the LFX workspace root, but always operates in lfx-v2-member-service. Every repo-convention finding quotes a loaded repo source. Pass the keyword `branch` to switch to full-branch mode (audits origin/main...HEAD). Invoke after every pre-PR commit in parallel with lfx-skills:lfx-general-code-reviewer."
 model: opus
 ---
+<!-- Copyright The Linux Foundation and each contributor to LFX. -->
+<!-- SPDX-License-Identifier: MIT -->
 
 # LFX Member Service Code Reviewer
 

--- a/agents/lfx-member-service-learnings-reviewer.md
+++ b/agents/lfx-member-service-learnings-reviewer.md
@@ -3,6 +3,8 @@ name: lfx-member-service-learnings-reviewer
 description: "Post-commit empirical-pattern review for lfx-v2-member-service. Audits the latest commit in the lfx-v2-member-service repo against `docs/reviews/knowledge-base/` — patterns extracted from past PR review comments on this repo (Copilot + heavy human maintainer review; CodeRabbit is not active here). May be launched from the LFX workspace root, but always operates in `lfx-v2-member-service`. Findings are gated by KB matches: every finding must quote a pattern entry; unsourced findings are dropped. Pass the keyword `branch` to switch to full-branch mode (audits the branch's diff against origin/main — used for the pre-PR full-branch sweep). Renders a markdown review. Invoke after every commit while pre-PR, in parallel with `lfx-skills:lfx-member-service-code-reviewer`."
 model: opus
 ---
+<!-- Copyright The Linux Foundation and each contributor to LFX. -->
+<!-- SPDX-License-Identifier: MIT -->
 
 # LFX Member Service Learnings Reviewer
 

--- a/agents/lfx-newsletter-service-code-reviewer.md
+++ b/agents/lfx-newsletter-service-code-reviewer.md
@@ -3,6 +3,8 @@ name: lfx-newsletter-service-code-reviewer
 description: "Post-commit code-convention audit for lfx-v2-newsletter-service. Audits the latest commit in the lfx-v2-newsletter-service repo against the repo documented rule surface: CLAUDE.md, .claude/skills/newsletter-service-dev, repo contract docs, local chart docs, Makefile conventions, and relevant sibling-service contracts. May be launched from the LFX workspace root, but always operates in lfx-v2-newsletter-service. Every repo-convention finding quotes a loaded source. Pass the keyword `branch` to switch to full-branch mode against origin/main for the pre-PR branch sweep. Invoke after every pre-PR commit in parallel with lfx-skills:lfx-general-code-reviewer."
 model: opus
 ---
+<!-- Copyright The Linux Foundation and each contributor to LFX. -->
+<!-- SPDX-License-Identifier: MIT -->
 
 # LFX Newsletter Service Code Reviewer
 

--- a/agents/lfx-newsletter-service-learnings-reviewer.md
+++ b/agents/lfx-newsletter-service-learnings-reviewer.md
@@ -3,6 +3,8 @@ name: lfx-newsletter-service-learnings-reviewer
 description: "Post-commit empirical-pattern review for lfx-v2-newsletter-service. Audits the latest commit in the lfx-v2-newsletter-service repo against `docs/reviews/knowledge-base/` — patterns extracted from past PR review comments on this repo. May be launched from the LFX workspace root, but always operates in `lfx-v2-newsletter-service`. Findings are gated by KB matches: every finding must quote a pattern entry; unsourced findings are dropped. Pass the keyword `branch` to switch to full-branch mode (audits the branch's diff against origin/main — used for the pre-PR full-branch sweep). Renders a markdown review. Invoke after every commit while pre-PR, in parallel with `lfx-skills:lfx-newsletter-service-code-reviewer`."
 model: opus
 ---
+<!-- Copyright The Linux Foundation and each contributor to LFX. -->
+<!-- SPDX-License-Identifier: MIT -->
 
 # LFX Newsletter Service Learnings Reviewer
 

--- a/agents/lfx-project-service-code-reviewer.md
+++ b/agents/lfx-project-service-code-reviewer.md
@@ -3,6 +3,8 @@ name: lfx-project-service-code-reviewer
 description: "Post-commit code-convention audit for lfx-v2-project-service. Audits the latest commit in the lfx-v2-project-service repo against the repo documented rule surface: CLAUDE.md, .claude/skills/project-service-dev, project-service readiness/preflight scope boundaries, README/DEVELOPMENT, Goa design/gen layout, NATS/KV rules, indexer/FGA contract docs, chart docs, Makefile, and current code. May be launched from the LFX workspace root, but always operates in lfx-v2-project-service. Every repo-convention finding quotes a loaded source. Pass the keyword `branch` to switch to full-branch mode, auditing the branch diff against origin/main for the pre-PR sweep. Invoke after every pre-PR commit in parallel with lfx-skills:lfx-general-code-reviewer."
 model: opus
 ---
+<!-- Copyright The Linux Foundation and each contributor to LFX. -->
+<!-- SPDX-License-Identifier: MIT -->
 
 # LFX Project Service Code Reviewer
 

--- a/agents/lfx-project-service-learnings-reviewer.md
+++ b/agents/lfx-project-service-learnings-reviewer.md
@@ -3,6 +3,8 @@ name: lfx-project-service-learnings-reviewer
 description: "Post-commit empirical-pattern review for lfx-v2-project-service. Audits the latest commit in the lfx-v2-project-service repo against `docs/reviews/knowledge-base/` — patterns extracted from past PR review comments on this repo. May be launched from the LFX workspace root, but always operates in `lfx-v2-project-service`. Findings are gated by KB matches: every finding must quote a pattern entry; unsourced findings are dropped. Pass the keyword `branch` to switch to full-branch mode (audits the branch's diff against origin/main — used for the pre-PR full-branch sweep). Renders a markdown review. Invoke after every commit while pre-PR, in parallel with `lfx-skills:lfx-project-service-code-reviewer`."
 model: opus
 ---
+<!-- Copyright The Linux Foundation and each contributor to LFX. -->
+<!-- SPDX-License-Identifier: MIT -->
 
 # LFX Project Service Learnings Reviewer
 

--- a/agents/lfx-self-serve-code-reviewer.md
+++ b/agents/lfx-self-serve-code-reviewer.md
@@ -3,6 +3,8 @@ name: lfx-self-serve-code-reviewer
 description: "Post-commit code-convention audit for lfx-self-serve. Audits the latest commit in the lfx-self-serve repo against the repo documented rule surface: `.claude/rules/`, the four `docs/reviews/` checklists, architecture docs, and upstream API contracts. May be launched from the LFX workspace root, but always operates in `lfx-self-serve`. Every repo-convention finding quotes a loaded source. Pass the keyword `branch` to switch to full-branch mode (audits the branch's diff against main — used for the pre-PR full-branch sweep and by `/lfx-review-pr`). Renders a markdown review with Upstream API / data-layer validation and Repo conventions sections. Invoke after every commit while pre-PR, in parallel with `lfx-skills:lfx-general-code-reviewer` and `lfx-skills:lfx-self-serve-learnings-reviewer`."
 model: opus
 ---
+<!-- Copyright The Linux Foundation and each contributor to LFX. -->
+<!-- SPDX-License-Identifier: MIT -->
 
 # LFX Self-Serve Code Reviewer
 

--- a/agents/lfx-self-serve-learnings-reviewer.md
+++ b/agents/lfx-self-serve-learnings-reviewer.md
@@ -3,6 +3,8 @@ name: lfx-self-serve-learnings-reviewer
 description: "Post-commit empirical-pattern review for lfx-self-serve. Audits the latest commit in the lfx-self-serve repo against `docs/reviews/knowledge-base/` — patterns extracted from past PR review comments on this repo. May be launched from the LFX workspace root, but always operates in `lfx-self-serve`. Findings are gated by KB matches: every finding must quote a pattern entry; unsourced findings are dropped. Pass the keyword `branch` to switch to full-branch mode (audits the branch's diff against main — used for the pre-PR full-branch sweep and by `/lfx-review-pr`). Renders a markdown review. Invoke after every commit while pre-PR, in parallel with `lfx-skills:lfx-self-serve-code-reviewer`."
 model: opus
 ---
+<!-- Copyright The Linux Foundation and each contributor to LFX. -->
+<!-- SPDX-License-Identifier: MIT -->
 
 # LFX Self-Serve Learnings Reviewer
 

--- a/skills/lfx-cdp-snowflake-connectors/SKILL.md
+++ b/skills/lfx-cdp-snowflake-connectors/SKILL.md
@@ -4,6 +4,9 @@ description: Use when adding a new snowflake-connector data source to crowd.dev 
 allowed-tools: Bash, Read, Write, Edit, Glob, Grep, AskUserQuestion, mcp__claude_ai_LFX_BI_Layer__get_all_sources, mcp__claude_ai_LFX_BI_Layer__get_source_details, mcp__claude_ai_LFX_BI_Layer__list_metrics, mcp__claude_ai_LFX_BI_Layer__get_dimensions, mcp__claude_ai_LFX_BI_Layer__query_metrics
 ---
 
+<!-- Copyright The Linux Foundation and each contributor to LFX. -->
+<!-- SPDX-License-Identifier: MIT -->
+
 # Scaffold Snowflake Connector
 
 ## Overview

--- a/skills/lfx-itx-integration/SKILL.md
+++ b/skills/lfx-itx-integration/SKILL.md
@@ -1,6 +1,4 @@
 ---
-# Copyright The Linux Foundation and each contributor to LFX.
-# SPDX-License-Identifier: MIT
 name: lfx-itx-integration
 description: >
   Central explainer for how LFX V2 wrapper services integrate with ITX (the
@@ -18,6 +16,9 @@ description: >
   wrapper repo.
 allowed-tools: Read, Glob, Grep
 ---
+
+<!-- Copyright The Linux Foundation and each contributor to LFX. -->
+<!-- SPDX-License-Identifier: MIT -->
 
 # LFX ITX Integration
 

--- a/skills/lfx-platform-architecture/SKILL.md
+++ b/skills/lfx-platform-architecture/SKILL.md
@@ -1,6 +1,4 @@
 ---
-# Copyright The Linux Foundation and each contributor to LFX.
-# SPDX-License-Identifier: MIT
 name: lfx-platform-architecture
 description: >
   Central explainer for how the LFX V2 platform components compose: Self Serve,
@@ -17,6 +15,9 @@ description: >
   repo's path-scoped `<short-repo-name>-dev` skill should attach after routing.
 allowed-tools: Read, Glob, Grep
 ---
+
+<!-- Copyright The Linux Foundation and each contributor to LFX. -->
+<!-- SPDX-License-Identifier: MIT -->
 
 # LFX Platform Architecture
 

--- a/skills/lfx-test-journey/SKILL.md
+++ b/skills/lfx-test-journey/SKILL.md
@@ -1,6 +1,4 @@
 ---
-# Copyright The Linux Foundation and each contributor to LFX.
-# SPDX-License-Identifier: MIT
 name: lfx-test-journey
 description: >
   Combine multiple feature branches across repos into worktrees for
@@ -9,6 +7,8 @@ description: >
 allowed-tools: Bash, Read, Write, Edit, Glob, Grep, AskUserQuestion
 ---
 
+<!-- Copyright The Linux Foundation and each contributor to LFX. -->
+<!-- SPDX-License-Identifier: MIT -->
 <!-- Tool names in this file use Claude Code vocabulary. See docs/tool-mapping.md for other platforms. -->
 
 # Journey Testing: Multi-Branch Integration Worktrees

--- a/skills/lfx/SKILL.md
+++ b/skills/lfx/SKILL.md
@@ -1,6 +1,4 @@
 ---
-# Copyright The Linux Foundation and each contributor to LFX.
-# SPDX-License-Identifier: MIT
 name: lfx
 description: >
   LFX cross-repo topology and ownership router. Use when the task spans more
@@ -20,6 +18,9 @@ description: >
   (`/lfx-skills:lfx-intercom`).
 allowed-tools: Bash, Read, Glob, Grep, AskUserQuestion
 ---
+
+<!-- Copyright The Linux Foundation and each contributor to LFX. -->
+<!-- SPDX-License-Identifier: MIT -->
 
 # LFX
 


### PR DESCRIPTION
## Summary

- Add the standard LFX MIT license comment block below YAML frontmatter in all 13 reviewer agent definitions and 5 skill files that were missing or had misplaced headers.
- Move license headers out of YAML frontmatter in `lfx`, `lfx-itx-integration`, `lfx-platform-architecture`, and `lfx-test-journey` SKILL.md files (HTML comments after closing `---`).
- Prepend the standard header to `README.md`.

All 50 markdown files in the repo now follow the documented convention: frontmatter-bearing files (skills and agents) use HTML comment headers immediately below frontmatter; plain markdown uses the header at line 1.

## Test plan

- [x] Audit script confirms 0 license header placement issues across 50 `.md` files
- [ ] License Header Check CI workflow passes on this PR
- [ ] Spot-check: skills with tool-mapping comments still have license header before that comment (`lfx-test-journey`, `lfx-setup`, etc.)


Made with [Cursor](https://cursor.com)